### PR TITLE
Refine study schedule with chapter-based progress and Railway API URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,16 +44,16 @@
         <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
             <h1 class="text-3xl font-bold text-gray-900 mb-2">eWPTX Exam Prep Tracker</h1>
             <p class="text-gray-600 mb-4">
-                <span id="days-remaining" class="font-semibold text-red-600">15</span> days remaining until August 31st
+                <span id="days-remaining" class="font-semibold text-red-600">14</span> days remaining until August 31st
             </p>
             
             <div class="bg-blue-50 rounded-lg p-4">
                 <div class="flex justify-between items-center mb-2">
                     <span class="text-sm font-medium text-blue-700">Overall Progress</span>
-                    <span class="text-sm font-medium text-blue-700"><span id="overall-progress-text">0</span>%</span>
+                    <span class="text-sm font-medium text-blue-700"><span id="overall-progress-text">53</span>%</span>
                 </div>
                 <div class="w-full bg-blue-200 rounded-full h-3">
-                    <div id="overall-progress-bar" class="bg-blue-600 h-3 rounded-full progress-bar" style="width: 0%"></div>
+                    <div id="overall-progress-bar" class="bg-blue-600 h-3 rounded-full progress-bar" style="width: 53%"></div>
                 </div>
             </div>
         </div>
@@ -65,39 +65,39 @@
                 <h3 class="text-lg font-semibold text-gray-900 mb-4">eWPTX Study Schedule</h3>
                 <div class="space-y-4">
                     <div class="bg-blue-50 p-4 rounded-lg">
-                        <h4 class="font-semibold text-blue-800 mb-2">Current: Chapter 9 - XML (50% done)</h4>
+                        <h4 class="font-semibold text-blue-800 mb-2">Current: XML Labs (Ch 9 complete)</h4>
                         <div class="text-sm text-blue-700 space-y-1">
-                            <div>• Aug 17-18: Finish XML theory (2.5 hrs remaining)</div>
-                            <div>• PortSwigger: XML injection labs (2 hrs)</div>
-                            <div>• Daily labs: 2-3 XML injection labs (1.5 hrs)</div>
+                            <div>• Aug 17: Finished INE XML theory (105 pages ~4 hrs)</div>
+                            <div>• Aug 18-19: 3 XML labs/day (45 mins each, check solution after deadline)</div>
+                            <div>• PortSwigger reading only if extra info (~1 hr)</div>
                         </div>
                     </div>
                     
                     <div class="space-y-3 text-sm">
                         <div class="border-l-4 border-green-500 pl-3">
-                            <strong>Aug 19-22: Chapter 10 - Serialization</strong><br>
-                            <span class="text-gray-600">4 days • 155 pages • ~6 hrs theory + PortSwigger labs</span><br>
-                            <span class="text-xs text-green-600">Daily: 3-4 serialization labs (2 hrs)</span>
+                            <strong>Aug 20-23: Chapter 10 - Serialization</strong><br>
+                            <span class="text-gray-600">4 days • 155 pages • ~6 hrs INE theory + optional 1 hr PortSwigger</span><br>
+                            <span class="text-xs text-green-600">Daily: 3-4 serialization labs (45 mins each; view solution after deadline)</span>
                         </div>
-                        
+
                         <div class="border-l-4 border-blue-500 pl-3">
-                            <strong>Aug 23-26: Chapter 11 - SSRF</strong><br>
-                            <span class="text-gray-600">4 days • 147 pages • ~5.5 hrs theory + PortSwigger labs</span><br>
-                            <span class="text-xs text-blue-600">Daily: 2-3 SSRF labs (1.5 hrs)</span>
+                            <strong>Aug 24-27: Chapter 11 - SSRF</strong><br>
+                            <span class="text-gray-600">4 days • 147 pages • ~5.5 hrs INE theory + optional 1 hr PortSwigger</span><br>
+                            <span class="text-xs text-blue-600">Daily: 2-3 SSRF labs (45 mins each; view solution after deadline)</span>
                         </div>
-                        
+
                         <div class="border-l-4 border-purple-500 pl-3">
-                            <strong>Aug 27-28: Chapter 12 - Crypto</strong><br>
-                            <span class="text-gray-600">2 days • 44 pages • ~2 hrs theory + PortSwigger labs</span><br>
-                            <span class="text-xs text-purple-600">Daily: 2-3 crypto labs (1.5 hrs)</span>
+                            <strong>Aug 28-29: Chapter 12 - Crypto</strong><br>
+                            <span class="text-gray-600">2 days • 44 pages • ~2 hrs INE theory + optional 0.5 hr PortSwigger</span><br>
+                            <span class="text-xs text-purple-600">Daily: 2-3 crypto labs (45 mins each; view solution after deadline)</span>
                         </div>
-                        
+
                         <div class="border-l-4 border-orange-500 pl-3">
-                            <strong>Aug 29-30: Chapter 13 - Auth & SSO</strong><br>
-                            <span class="text-gray-600">2 days • 80 pages • ~3 hrs theory + PortSwigger labs</span><br>
-                            <span class="text-xs text-orange-600">Daily: 3-4 auth labs (2 hrs)</span>
+                            <strong>Aug 30: Chapter 13 - Auth & SSO</strong><br>
+                            <span class="text-gray-600">1 day • 80 pages • ~3 hrs INE theory + optional 1 hr PortSwigger</span><br>
+                            <span class="text-xs text-orange-600">Daily: 3-4 auth labs (45 mins each; view solution after deadline)</span>
                         </div>
-                        
+
                         <div class="border-l-4 border-red-500 pl-3">
                             <strong>Aug 31: Final Review</strong><br>
                             <span class="text-gray-600">Mock exam + weak areas review</span>
@@ -154,12 +154,13 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                 <div>
                     <strong class="text-amber-700">Sep 1-3: Chapter 14 - API & Cloud (130 pages)</strong><br>
-                    <span class="text-amber-600">• 5 hrs theory + extensive API testing labs</span><br>
-                    <span class="text-amber-600">• Focus on REST/GraphQL vulnerabilities</span>
+                    <span class="text-amber-600">• ~5 hrs INE theory + optional 1 hr PortSwigger</span><br>
+                    <span class="text-amber-600">• Daily: 3-4 API labs (45 mins each)</span>
                 </div>
                 <div>
                     <strong class="text-amber-700">Sep 4-5: Chapter 15 - LDAP (50 pages)</strong><br>
-                    <span class="text-amber-600">• 2 hrs theory + LDAP injection labs</span><br>
+                    <span class="text-amber-600">• ~2 hrs INE theory + optional 1 hr PortSwigger</span><br>
+                    <span class="text-amber-600">• Daily: 2-3 LDAP labs (45 mins each)</span><br>
                     <span class="text-amber-600">• Sep 6: Final comprehensive review</span>
                 </div>
             </div>
@@ -201,6 +202,10 @@
         
         let completedTasks = {};
         const remainingDays = Array.from({length: 15}, (_, i) => i + 17);
+        const BASE_COMPLETED_CHAPTERS = 8;
+        const TOTAL_CHAPTERS = 15;
+        const baseProgress = Math.round((BASE_COMPLETED_CHAPTERS / TOTAL_CHAPTERS) * 100);
+
 
         // API Functions
         async function saveToAPI(data) {
@@ -272,7 +277,8 @@
         function getOverallProgress() {
             const totalTasks = remainingDays.length * dailyTasks.length;
             const completedCount = Object.values(completedTasks).filter(Boolean).length;
-            return Math.round((completedCount / totalTasks) * 100);
+            const scaled = Math.round((completedCount / totalTasks) * (100 - baseProgress));
+            return baseProgress + scaled;
         }
 
         function updateUI() {


### PR DESCRIPTION
## Summary
- Start overall progress bar at 53% to reflect eight completed chapters.
- Compute overall progress from remaining daily tasks relative to that baseline.
- Confirm Railway API endpoint configuration.

## Testing
- `tidy -e index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a219f5f94c832390ec1d7a44737253