### PR TITLE
Add day-specific checklists to study tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,36 +198,71 @@
     </div>
 
     <script>
-        const dailyTasks = [
-            { id: 'study_morning', task: 'Morning review (8:00-9:00 AM)', icon: '📚' },
-            { id: 'study_theory', task: 'Evening INE theory (7:00-8:30 PM)', icon: '📖' },
-            { id: 'portswigger_read', task: 'PortSwigger reading (if needed)', icon: '📰' },
-            { id: 'study_labs', task: 'Labs (8:30-10:00 PM)', icon: '💻' }
-        ];
-
-        const dailyDetails = {
-            17: 'Complete XML theory (Ch 9, 105 pages)',
-            18: '3 XML labs (45 mins each)',
-            19: '3 XML labs (45 mins each)',
-            20: 'Ch 10 Serialization p1-40; 3-4 serialization labs',
-            21: 'Ch 10 Serialization p41-80; 3-4 serialization labs',
-            22: 'Ch 10 Serialization p81-120; 3-4 serialization labs',
-            23: 'Ch 10 Serialization p121-155; 3-4 serialization labs',
-            24: 'Ch 11 SSRF p1-37; 2-3 SSRF labs',
-            25: 'Ch 11 SSRF p38-74; 2-3 SSRF labs',
-            26: 'Ch 11 SSRF p75-111; 2-3 SSRF labs',
-            27: 'Ch 11 SSRF p112-147; 2-3 SSRF labs',
-            28: 'Ch 12 Crypto p1-22; 2-3 crypto labs',
-            29: 'Ch 12 Crypto p23-44; 2-3 crypto labs',
-            30: 'Ch 13 Auth & SSO p1-80; 3-4 auth labs',
-            31: 'Mock exam & review'
+        const dailyTasks = {
+            17: [
+                { id: 'xml_theory', task: 'Complete XML theory (Ch 9, 105 pages)', icon: '📘' }
+            ],
+            18: [
+                { id: 'xml_labs_1', task: '3 XML labs (45 mins each)', icon: '💻' }
+            ],
+            19: [
+                { id: 'xml_labs_2', task: '3 XML labs (45 mins each)', icon: '💻' }
+            ],
+            20: [
+                { id: 'serial_read_1', task: 'Ch 10 Serialization p1-40 (~1.5h INE + optional 1h PortSwigger)', icon: '📘' },
+                { id: 'serial_labs_1', task: '3-4 serialization labs', icon: '💻' }
+            ],
+            21: [
+                { id: 'serial_read_2', task: 'Ch 10 Serialization p41-80 (~1.5h INE + optional 1h PortSwigger)', icon: '📘' },
+                { id: 'serial_labs_2', task: '3-4 serialization labs', icon: '💻' }
+            ],
+            22: [
+                { id: 'serial_read_3', task: 'Ch 10 Serialization p81-120 (~1.5h INE + optional 1h PortSwigger)', icon: '📘' },
+                { id: 'serial_labs_3', task: '3-4 serialization labs', icon: '💻' }
+            ],
+            23: [
+                { id: 'serial_read_4', task: 'Ch 10 Serialization p121-155 (~1.5h INE + optional 1h PortSwigger)', icon: '📘' },
+                { id: 'serial_labs_4', task: '3-4 serialization labs', icon: '💻' }
+            ],
+            24: [
+                { id: 'ssrf_read_1', task: 'Ch 11 SSRF p1-37 (~1.5h INE + optional 1h PortSwigger)', icon: '📘' },
+                { id: 'ssrf_labs_1', task: '2-3 SSRF labs', icon: '💻' }
+            ],
+            25: [
+                { id: 'ssrf_read_2', task: 'Ch 11 SSRF p38-74 (~1.5h INE + optional 1h PortSwigger)', icon: '📘' },
+                { id: 'ssrf_labs_2', task: '2-3 SSRF labs', icon: '💻' }
+            ],
+            26: [
+                { id: 'ssrf_read_3', task: 'Ch 11 SSRF p75-111 (~1.5h INE + optional 1h PortSwigger)', icon: '📘' },
+                { id: 'ssrf_labs_3', task: '2-3 SSRF labs', icon: '💻' }
+            ],
+            27: [
+                { id: 'ssrf_read_4', task: 'Ch 11 SSRF p112-147 (~1.5h INE + optional 1h PortSwigger)', icon: '📘' },
+                { id: 'ssrf_labs_4', task: '2-3 SSRF labs', icon: '💻' }
+            ],
+            28: [
+                { id: 'crypto_read_1', task: 'Ch 12 Crypto p1-22 (~1h INE + optional 0.5h PortSwigger)', icon: '📘' },
+                { id: 'crypto_labs_1', task: '2-3 crypto labs', icon: '💻' }
+            ],
+            29: [
+                { id: 'crypto_read_2', task: 'Ch 12 Crypto p23-44 (~1h INE + optional 0.5h PortSwigger)', icon: '📘' },
+                { id: 'crypto_labs_2', task: '2-3 crypto labs', icon: '💻' }
+            ],
+            30: [
+                { id: 'auth_read', task: 'Ch 13 Auth & SSO p1-80 (~3h INE + optional 1h PortSwigger)', icon: '📘' },
+                { id: 'auth_labs', task: '3-4 auth labs', icon: '💻' }
+            ],
+            31: [
+                { id: 'mock_exam', task: 'Mock exam', icon: '📝' },
+                { id: 'review', task: 'Review weak areas', icon: '🔍' }
+            ]
         };
 
         // API Configuration
         const API_BASE_URL = 'https://my-todo-list-production-ac74.up.railway.app/api'; // Replace with your Railway URL
         
         let completedTasks = {};
-        const remainingDays = Array.from({length: 15}, (_, i) => i + 17);
+        const remainingDays = Object.keys(dailyTasks).map(Number);
         const BASE_COMPLETED_CHAPTERS = 8;
         const TOTAL_CHAPTERS = 15;
         const baseProgress = Math.round((BASE_COMPLETED_CHAPTERS / TOTAL_CHAPTERS) * 100);
@@ -294,16 +329,15 @@
         }
 
         function getDayProgress(day) {
-            const completed = dailyTasks.filter(task => 
-                completedTasks[`${day}-${task.id}`]
-            ).length;
-            return Math.round((completed / dailyTasks.length) * 100);
+            const tasks = dailyTasks[day] || [];
+            const completed = tasks.filter(task => completedTasks[`${day}-${task.id}`]).length;
+            return tasks.length ? Math.round((completed / tasks.length) * 100) : 0;
         }
 
         function getOverallProgress() {
-            const totalTasks = remainingDays.length * dailyTasks.length;
+            const totalTasks = remainingDays.reduce((sum, d) => sum + (dailyTasks[d]?.length || 0), 0);
             const completedCount = Object.values(completedTasks).filter(Boolean).length;
-            const scaled = Math.round((completedCount / totalTasks) * (100 - baseProgress));
+            const scaled = totalTasks ? Math.round((completedCount / totalTasks) * (100 - baseProgress)) : 0;
             return baseProgress + scaled;
         }
 
@@ -315,24 +349,25 @@
 
             // Update day cards
             remainingDays.forEach(day => {
+                const dayTasks = dailyTasks[day] || [];
                 const dayProgress = getDayProgress(day);
                 const progressElement = document.getElementById(`progress-${day}`);
-                
+
                 if (progressElement) {
                     progressElement.textContent = `${dayProgress}%`;
                     progressElement.className = `text-xs font-medium px-2 py-1 rounded-full ${
-                        dayProgress === 100 ? 'bg-green-100 text-green-800' : 
+                        dayProgress === 100 ? 'bg-green-100 text-green-800' :
                         dayProgress > 0 ? 'bg-yellow-100 text-yellow-800' : 'bg-gray-100 text-gray-600'
                     }`;
                 }
 
                 // Update tasks
-                dailyTasks.forEach(task => {
+                dayTasks.forEach(task => {
                     const isCompleted = completedTasks[`${day}-${task.id}`];
                     const taskElement = document.getElementById(`task-${day}-${task.id}`);
                     const textElement = document.getElementById(`text-${day}-${task.id}`);
                     const checkbox = taskElement?.querySelector('input[type="checkbox"]');
-                    
+
                     if (taskElement && textElement && checkbox) {
                         taskElement.className = `task-item flex items-center p-2 rounded cursor-pointer ${
                             isCompleted ? 'bg-green-50' : 'hover:bg-gray-50'
@@ -350,6 +385,7 @@
             const container = document.getElementById('daily-cards');
             
             remainingDays.forEach(day => {
+                const tasks = dailyTasks[day] || [];
                 const card = document.createElement('div');
                   card.className = 'bg-white rounded-lg shadow-sm p-4 card';
                   card.innerHTML = `
@@ -359,9 +395,8 @@
                               0%
                           </div>
                       </div>
-                      <p class="text-xs text-gray-600 mb-2">${dailyDetails[day] || ''}</p>
                       <div class="space-y-1">
-                          ${dailyTasks.map(task => `
+                          ${tasks.map(task => `
                               <div
                                   id="task-${day}-${task.id}"
                                   class="task-item flex items-center p-2 rounded cursor-pointer hover:bg-gray-50"


### PR DESCRIPTION
## Summary
- Replace generic tasks with per-day checklists for Aug 17–31
- Update progress and UI logic to handle varying daily tasks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a22273d45c8323837d949bb337f819